### PR TITLE
Add support for global DOF spring springs

### DIFF
--- a/ASMu2DNastran.C
+++ b/ASMu2DNastran.C
@@ -22,9 +22,9 @@
 #include <sstream>
 
 namespace ASM {
-  double Ktra = 0.0;
-  double Krot = 0.0;
-  bool skipVTFmass = false;
+  bool skipVTFmass = false; //!< If \e true, skip mass point geometries in VTF
+  double Ktra = 0.0; //!< Translation stiffness for added springs in slave nodes
+  double Krot = 0.0; //!< Rotation stiffness for added sprins in slave nodes
 }
 
 
@@ -44,6 +44,10 @@ namespace ASM {
 #include "FFlFEParts/FFlPBEAMECCENT.H"
 #include "FFlFEParts/FFlPORIENT.H"
 #include <unordered_map>
+
+namespace FFlNastran {
+  extern std::string mainPath;
+}
 
 
 /*!
@@ -99,6 +103,19 @@ public:
 #endif
 
 std::vector<int> ASMu2DNastran::fixRBE3;
+
+
+ASMu2DNastran::ASMu2DNastran (unsigned char n, unsigned char n_f,
+                              const std::string& path, bool sets, char beams)
+  : ASMu2DLag(n,n_f,'N'), useBeams(beams), readSets(sets)
+{
+  massMax = 1.0;
+  beamPatch = nullptr;
+  nGnod.fill(0);
+#ifdef HAS_FFLLIB
+  FFlNastran::mainPath = path;
+#endif
+}
 
 
 ASMu2DNastran::~ASMu2DNastran ()

--- a/ASMu2DNastran.h
+++ b/ASMu2DNastran.h
@@ -32,9 +32,8 @@ class ASMu2DNastran : public ASMu2DLag
 {
 public:
   //! \brief The constructor forwards to the parent class constructor.
-  ASMu2DNastran(unsigned char n, unsigned char n_f, bool sets, char beams)
-    : ASMu2DLag(n,n_f,'N'), useBeams(beams), readSets(sets),
-      massMax(1.0), beamPatch(nullptr) { nGnod.fill(0); }
+  ASMu2DNastran(unsigned char n, unsigned char n_f,
+                const std::string& path, bool sets, char beams);
   //! \brief Disable default copy constructor.
   ASMu2DNastran(const ASMu2DNastran&) = delete;
   //! \brief The destructor deletes the immersed/extra element blocks, if any.

--- a/AndesShell.C
+++ b/AndesShell.C
@@ -109,7 +109,7 @@ AndesShell::~AndesShell ()
 }
 
 
-Material* AndesShell::parseMatProp (const tinyxml2::XMLElement* elem, bool)
+Material* AndesShell::parseMatProp (const tinyxml2::XMLElement* elem)
 {
   if (utl::getAttribute(elem,"override",ovrMat) && ovrMat)
   {

--- a/AndesShell.h
+++ b/AndesShell.h
@@ -43,7 +43,7 @@ public:
 
   using ElasticBase::parseMatProp;
   //! \brief Parses material properties from an XML-element.
-  virtual Material* parseMatProp(const tinyxml2::XMLElement* elem, bool);
+  virtual Material* parseMatProp(const tinyxml2::XMLElement* elem);
 
   //! \brief Prints out the problem definition to the log stream.
   virtual void printLog() const;

--- a/FFlLib/FFlLinkHandler.C
+++ b/FFlLib/FFlLinkHandler.C
@@ -346,7 +346,7 @@ void FFlLinkHandler::calculateChecksum(FFaCheckSum* cs,
       if (checkStrainCoat || !isStrainCoatProp(attr.second))
       {
         attr.second->calculateChecksum(cs,csType);
-#if FFL_DEBUG > 1
+#if FFL_DEBUG > 2
         std::cout <<"Link checksum after attribute "<< attr.first
                   <<" "<< attr.second->getID() <<" : "
                   << cs->getCurrent() << std::endl;
@@ -1270,7 +1270,7 @@ int FFlLinkHandler::addUniqueAttribute(FFlAttributeBase* attr, bool silence)
       return attp.first;
     }
 
-#ifdef FFL_DEBUG
+#if FFL_DEBUG > 2
   attr->print("Unique attribute ");
 #endif
 
@@ -1299,7 +1299,7 @@ int FFlLinkHandler::addUniqueAttributeCS(FFlAttributeBase*& attr)
     return attr->getID();
   }
 
-#ifdef FFL_DEBUG
+#if FFL_DEBUG > 2
   attr->print("Unique attribute ");
 #endif
 

--- a/FFlLib/FFlNastranReader.C
+++ b/FFlLib/FFlNastranReader.C
@@ -34,11 +34,13 @@
 
 #define MAX_HEADER_LINES 1000
 
+namespace FFlNastran {
+  std::string mainPath;
+}
+
 #ifdef FF_NAMESPACE
 namespace FF_NAMESPACE {
 #endif
-
-static std::string mainPath;
 
 static bool identFoundSet = false;
 static bool procOK        = true; // Set to false if parsing errors detected
@@ -192,10 +194,11 @@ void FFlNastranReader::readerCB (const std::string& fname, FFlLinkHandler* link)
 {
   nWarnings = nNotes = 0;
   FFlNastranReader reader(link,startBulk);
-  mainPath = FFaFilePath::getPath(fname);
+  FFlNastran::mainPath = FFaFilePath::getPath(fname);
 #ifdef FFL_DEBUG
   std::cout <<"FFlNastranReader: fileName = \""<< fname <<"\"\n"
-	    <<"FFlNastranReader: mainPath = \""<< mainPath <<"\""<< std::endl;
+            <<"FFlNastranReader: mainPath = \""<< FFlNastran::mainPath
+            <<"\""<< std::endl;
 #endif
   bool stillOk = reader.read(fname);
   bool setsOk  = true;
@@ -228,8 +231,8 @@ bool FFlNastranReader::read (const std::string& fname, bool includedFile)
   // the given fname is relative to the location of the main bulk data file
   std::string fileName(fname);
   if (includedFile)
-    if (FFaFilePath::isRelativePath(fname) && !mainPath.empty())
-      fileName = FFaFilePath::appendFileNameToPath(mainPath,fname);
+    if (FFaFilePath::isRelativePath(fname) && !FFlNastran::mainPath.empty())
+      fileName = FFaFilePath::appendFileNameToPath(FFlNastran::mainPath,fname);
   FFaFilePath::checkName(fileName);
 
   std::ifstream fs(fileName.c_str());
@@ -266,12 +269,12 @@ bool FFlNastranReader::read (const std::string& fname, bool includedFile)
   {
     nNotes++;
     ListUI <<"\n   * Note: "<< numOP2 <<" OP2-files were detected.\n"
-	   <<"           The FE part is assumed to be externally reduced.\n";
+           <<"           The FE part is assumed to be externally reduced.\n";
   }
 
 #ifdef FFL_DEBUG
   std::cout <<"FFlNastranReader: starting bulk data parsing at line "
-	    << lineCounter+1 << std::endl;
+            << lineCounter+1 << std::endl;
 #endif
   return this->read(fs);
 }
@@ -331,7 +334,7 @@ bool FFlNastranReader::read (std::istream& is)
 
 #ifdef FFL_DEBUG
   std::cout <<"FFlNastranReader: processed "<< lineCounter <<" lines (done)."
-	    << std::endl;
+            << std::endl;
 #endif
   STOPP_TIMER("read")
   return sizeOK && stillOK && procOK;
@@ -653,7 +656,7 @@ bool FFlNastranReader::getFields (std::istream& is, BulkEntry& entry)
 #if FFL_DEBUG > 4
   if (!entry.cont.empty())
     std::cout <<"FFlNastranReader: continuation field=\""<< entry.cont
-	      <<"\""<< std::endl;
+              <<"\""<< std::endl;
 #endif
 
   return true;
@@ -1122,7 +1125,7 @@ void FFlNastranReader::processAssignFile (const std::string& line)
   if (k == std::string::npos || k < j+2) return;
 
   std::string op2file = line.substr(j+1,k-j-1);
-  FFaFilePath::makeItAbsolute(op2file,mainPath);
+  FFaFilePath::makeItAbsolute(op2file,FFlNastran::mainPath);
   myLink->addOP2file(FFaFilePath::checkName(op2file));
 
   nNotes++;

--- a/FFlLib/FFlPartBase.H
+++ b/FFlLib/FFlPartBase.H
@@ -45,8 +45,8 @@ public:
 
 #ifdef FFL_REFCOUNT
   unsigned char getRefCount() const { return refCount; }
-  unsigned char ref() { return ++refCount; }
-  bool unref() { if (refCount) --refCount; return refCount > 0; }
+  unsigned char ref() { if (refCount < 255) ++refCount; return refCount; }
+  bool unref() { if (refCount < 255) --refCount; return refCount > 0; }
 #else
   unsigned char getRefCount() const { return 1; }
   unsigned char ref() { return 1; }

--- a/FFlLib/FFlReference.H
+++ b/FFlLib/FFlReference.H
@@ -9,6 +9,7 @@
 #define FFL_REFERENCE_H
 
 #include <map>
+#include <cstdint>
 
 #include "FFlLib/FFlPartBase.H"
 
@@ -102,10 +103,10 @@ public:
 
     using RefIt = typename std::map<int,T*>::const_iterator;
 
-    RefIt it = possibleRefs.find(myID);
-    if (it != possibleRefs.end())
+    RefIt r = possibleRefs.find(static_cast<int>(myID));
+    if (r != possibleRefs.end())
     {
-      myResolvedRef = it->second;
+      myResolvedRef = r->second;
       myResolvedRef->ref();
       iAmResolved = true;
     }
@@ -119,10 +120,10 @@ public:
 
     using RefIt = typename std::vector<T*>::const_iterator;
 
-    RefIt it = FFlPartFinder<T>::findObject(possibleRefs,myID);
-    if (it != possibleRefs.end())
+    RefIt r = FFlPartFinder<T>::findObject(possibleRefs,static_cast<int>(myID));
+    if (r != possibleRefs.end())
     {
-      myResolvedRef = *it;
+      myResolvedRef = *r;
       myResolvedRef->ref();
       iAmResolved = true;
     }
@@ -145,7 +146,10 @@ public:
 
   int getID() const
   {
-    return iAmResolved && myResolvedRef ? myResolvedRef->getID() : myID;
+    if (iAmResolved && myResolvedRef)
+      return myResolvedRef->getID();
+
+    return static_cast<int>(myID);
   }
 
 
@@ -166,21 +170,16 @@ private:
   bool iAmResolved;
 
   union {
-    T*  myResolvedRef;
-    int myID;
+    T* myResolvedRef;
+    std::intptr_t myID;
   };
-
-  friend bool operator< <T> (const FFlReference<T>& lhs,
-                             const FFlReference<T>& rhs);
 };
 
 
 template <class T>
 bool operator< (const FFlReference<T>& lhs, const FFlReference<T>& rhs)
 {
-  int lhsID = lhs.isResolved() ? lhs.myResolvedRef->getID() : lhs.myID;
-  int rhsID = rhs.isResolved() ? rhs.myResolvedRef->getID() : rhs.myID;
-  return lhsID < rhsID;
+  return lhs.getID() < rhs.getID();
 }
 
 #ifdef FF_NAMESPACE

--- a/SIMAndesShell.C
+++ b/SIMAndesShell.C
@@ -64,6 +64,18 @@ bool SIMAndesShell::parse (const tinyxml2::XMLElement* elem)
     const tinyxml2::XMLElement* child = elem->FirstChildElement("fixRBE3");
     if (child && child->FirstChild())
       utl::parseIntegers(ASMu2DNastran::fixRBE3,child->FirstChild()->Value());
+
+    std::string fName;
+    child = elem->FirstChildElement("patchfile");
+    if (child && child->FirstChild())
+      if (utl::getAttribute(child,"type",fName,true) && fName == "nastran")
+      {
+        // Extract the path of specified nastran file
+        fName = child->FirstChild()->Value();
+        size_t ipos = fName.find_last_of("/\\");
+        if (ipos < std::string::npos)
+          myPath = fName.substr(0,ipos);
+      }
   }
 
   if (!this->SIMElasticity<SIM2D>::parse(elem))
@@ -179,7 +191,7 @@ ASMbase* SIMAndesShell::readPatch (std::istream& isp, int, const CharVec&,
   ASMbase* pch = NULL;
   ASMu2DNastran* shell = NULL;
   if (nf.size() == 2 && nf[1] == 'n') // Nastran bulk data file
-    pch = shell = new ASMu2DNastran(nsd,nf.front(),readSets,useBeams);
+    pch = shell = new ASMu2DNastran(nsd,nf.front(),myPath,readSets,useBeams);
   else if (!(pch = ASM2D::create(opt.discretization,nsd,nf)))
     return pch;
 

--- a/SIMAndesShell.h
+++ b/SIMAndesShell.h
@@ -125,6 +125,7 @@ private:
 
   RealArray   myReact; //!< Nodal reaction forces
   std::string myRFset; //!< Node set for calculation of reaction forces
+  std::string myPath;  //!< Relative path of the patch file
 
   unsigned short int nss; //!< Number of consequtive solution states in core
 

--- a/SIMAndesShell.h
+++ b/SIMAndesShell.h
@@ -86,10 +86,10 @@ protected:
   //! \brief Dummy override, does nothing.
   virtual bool initBodyLoad(size_t) { return true; }
 
-  //! \brief Renumbers the global node numbers of the nodal point loads.
+  //! \brief Renumbers the global node numbers of the springs and point loads.
   virtual bool renumberNodes(const std::map<int,int>& nodeMap);
 
-  //! \brief Assembles the nodal point loads, if any.
+  //! \brief Assembles the DOF springs and nodal point loads, if any.
   virtual bool assembleDiscreteTerms(const IntegrandBase* itg,
                                      const TimeDomain& time);
 
@@ -98,17 +98,30 @@ public:
   static bool readSets; //!< If \e true, also read Nastran SET definitions
 
 private:
+  //! \brief Struct defining a DOF spring.
+  struct DOFspring
+  {
+    int    inod;  //!< Node index
+    int    ldof;  //!< Local DOF number
+    double coeff; //!< Stiffness coefficient
+    //! \brief Default constructor.
+    explicit DOFspring(int n = 0, int d = 0, double c = 0.0)
+      : inod(n), ldof(d), coeff(c) {}
+  };
+
   //! \brief Struct defining a nodal point load.
   struct PointLoad
   {
-    int         inod; //!< Node or patch index
+    int         inod; //!< Node index
     int         ldof; //!< Local DOF number
     ScalarFunc* p;    //!< Load magnitude
     //! \brief Default constructor.
-    PointLoad(int n = 0) : inod(n), ldof(0), p(nullptr) {}
+    explicit PointLoad(int n = 0, int d = 0, ScalarFunc* f = nullptr)
+      : inod(n), ldof(d), p(f) {}
   };
 
-  std::vector<PointLoad> myLoads; //!< Nodal point loads
+  std::vector<DOFspring> mySprings; //!< Global DOF springs
+  std::vector<PointLoad> myLoads;   //!< Nodal point loads
 
   RealArray   myReact; //!< Nodal reaction forces
   std::string myRFset; //!< Node set for calculation of reaction forces

--- a/main.C
+++ b/main.C
@@ -355,6 +355,7 @@ int main (int argc, char** argv)
     writer = model->getHDF5writer(displ.front(),dumpNodeMap);
 
   Vector load;
+  RealArray Fex;
   switch (iop+model->opt.eig) {
   case 0:
   case 200:
@@ -362,7 +363,7 @@ int main (int argc, char** argv)
     model->initForSingleStep();
     model->setMode(SIM::STATIC);
     model->setQuadratureRule(2,true);
-    model->initSystem(model->opt.solver);
+    model->initSystem(model->opt.solver,1,1,3);
     if (!model->assembleSystem(Elastic::time))
     {
       if (model->opt.format < 0)
@@ -376,6 +377,12 @@ int main (int argc, char** argv)
 #ifdef INT_DEBUG
       model->getSAM()->printVector(std::cout,load,"\nLoad vector");
 #endif
+    }
+    if (model->extractScalars(Fex))
+    {
+      IFEM::cout <<"\nTotal external load: Sum(Fex) =";
+      for (double f : Fex) IFEM::cout <<" "<< utl::trunc(f);
+      IFEM::cout << std::endl;
     }
 
     // Solve the linear system of equations


### PR DESCRIPTION
This adds xinp-tags for reading global DOFs springs into the model.
The syntax is one of

    <spring set="(setname)" dof="(1-6)">(stiffness coefficient)</DOFspring>
    <spring node="(node ID)" dof="(1-6)">(stiffness coefficient)</DOFspring>

In the first version `(setname)` is the name of a defined node set. In the second version , the node number is specified directly and is suitable when only one spring is needed.

Also in this PR the use of a map instead of `ASMbase::getNodeIndex()` is added to speed up the external-to-internal node number lookup, and some minor bugfixes in FFlLib.

Finally, a fix in the gravity load calculation and the integration of total external loads.

Requires OPM/IFEM-Elasticity#184 due to first commit (07e5fd07d1c0a44f3fe300b387262705d8ba0a9c).