### PR TITLE
Added: Use mkstemps to create temporary input file

### DIFF
--- a/ASMu2DNastran.h
+++ b/ASMu2DNastran.h
@@ -33,7 +33,8 @@ class ASMu2DNastran : public ASMu2DLag
 public:
   //! \brief The constructor forwards to the parent class constructor.
   ASMu2DNastran(unsigned char n, unsigned char n_f,
-                const std::string& path, bool sets, char beams);
+                const std::string& path, bool sets,
+                bool replaceRBE3, char beams);
   //! \brief Disable default copy constructor.
   ASMu2DNastran(const ASMu2DNastran&) = delete;
   //! \brief The destructor deletes the immersed/extra element blocks, if any.
@@ -145,6 +146,7 @@ private:
 
   char useBeams; //!< If nonzero include beam elements as a separate patch
   bool readSets; //!< If \e true, read the pre-bulk Nastran SET definitions
+  bool noRBE3s;  //!< If \e true, convert all RBE3 elements to RBE2 elements
 
   double massMax; //!< The largets point mass in the model (for scaling)
   IntMat spiders; //!< Constraint element topologies

--- a/SIMAndesShell.C
+++ b/SIMAndesShell.C
@@ -30,6 +30,7 @@
 
 char SIMAndesShell::useBeams = 1;
 bool SIMAndesShell::readSets = true;
+bool SIMAndesShell::replRBE3 = false;
 
 namespace Elastic { extern double time; }
 
@@ -191,7 +192,8 @@ ASMbase* SIMAndesShell::readPatch (std::istream& isp, int, const CharVec&,
   ASMbase* pch = NULL;
   ASMu2DNastran* shell = NULL;
   if (nf.size() == 2 && nf[1] == 'n') // Nastran bulk data file
-    pch = shell = new ASMu2DNastran(nsd,nf.front(),myPath,readSets,useBeams);
+    pch = shell = new ASMu2DNastran(nsd,nf.front(),myPath,
+                                    readSets,replRBE3,useBeams);
   else if (!(pch = ASM2D::create(opt.discretization,nsd,nf)))
     return pch;
 

--- a/SIMAndesShell.h
+++ b/SIMAndesShell.h
@@ -96,6 +96,7 @@ protected:
 public:
   static char useBeams; //!< If non-zero, include beam elements, if any
   static bool readSets; //!< If \e true, also read Nastran SET definitions
+  static bool replRBE3; //!< If \e true, replace all RBE3 elements by RBE2s
 
 private:
   //! \brief Struct defining a DOF spring.

--- a/main.C
+++ b/main.C
@@ -71,6 +71,7 @@ namespace ASM { extern double Ktra, Krot; extern bool skipVTFmass; }
   \arg -noSets : Ignore Nastran SET definitions
   \arg -noBeams : Ignore beam elements
   \arg -noEccs : Ignore beam end offsets
+  \arg -noRBE3 : Replace RBE3 elements by equivalent RBE2 elements
   \arg -dumpNodeMap : Dump Local-to-global node number mapping to HDF5
   \arg -split : Split the model into two material regions
   \arg -keep-previous-state : Use previous state when evaluating the
@@ -132,6 +133,8 @@ int main (int argc, char** argv)
       SIMAndesShell::useBeams = 0;
     else if (!strcmp(argv[i],"-noEccs"))
       SIMAndesShell::useBeams = 2;
+    else if (!strcmp(argv[i],"-noRBE3"))
+      SIMAndesShell::replRBE3 = true;
     else if (!strcmp(argv[i],"-Kbush"))
     {
       if (i+1 < argc && argv[i+1][0] != '-')
@@ -250,7 +253,7 @@ int main (int argc, char** argv)
                "[-no-vtfmass]]",
                "[-hdf5 [<filename>] [-dumpNodeMap]]","[-fixDup [<tol>]]",
                "[-refsol <files>]","[-noBeams]","[-noEccs]","[-noSets]",
-               "[-split]"});
+               "[-noRBE3]","[-split]"});
     delete prof;
     return 0;
   }

--- a/main.C
+++ b/main.C
@@ -29,9 +29,10 @@
 #endif
 #include <array>
 #include <fstream>
-#include <stdlib.h>
-#include <string.h>
 #include <ctype.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 namespace ASM { extern double Ktra, Krot; extern bool skipVTFmass; }
 
@@ -204,13 +205,18 @@ int main (int argc, char** argv)
   if (bdfile)
   {
     // Create a temporary input file referring to the Nastran bulk data file
-    static const char* tmpname = "/tmp/tmp.xinp";
+    static char tmpname[24] = "/tmp/tmp_XXXXXX.xinp";
+    int fd = mkstemps(tmpname,5);
     infile = const_cast<char*>(tmpname);
-    std::ofstream xinp(infile);
-    xinp <<"<simulation><geometry dim=\"3\">\n"
-         <<"  <patchfile type=\"Nastran\">"<< bdfile <<"</patchfile>\n"
-         <<"</geometry></simulation>\n";
-
+    std::string xinp = "<simulation><geometry dim=\"3\">\n"
+      "  <patchfile type=\"Nastran\">" + std::string(bdfile) +
+      "</patchfile>\n</geometry></simulation>\n";
+    if (write(fd,xinp.c_str(),xinp.size()) < 0)
+    {
+      std::cerr <<" *** Failed to write temporary file "<< tmpname << std::endl;
+      return false;
+    }
+    close(fd);
     if (IFEM::getOptions().format >= 0)
     {
       // Set default vtf file name


### PR DESCRIPTION
To avoid problems when running i parallel.

Also an option to replace all RBE3 element by RBE2 (for model-debugging).